### PR TITLE
Fix off-by-one in initial pos for menus with no header

### DIFF
--- a/clintermission/climenu.py
+++ b/clintermission/climenu.py
@@ -336,7 +336,10 @@ class CliMenu:
                         self._searchbar])
 
         # set initial pos
-        for _ in range(self._initial_pos + 1):
+        while not self._items[self._pos].focusable:
+            self._pos += 1
+
+        for _ in range(self._initial_pos):
             self.next_item(1)
 
         app = Application(layout=Layout(split),


### PR DESCRIPTION
Menus without a header had their initial position set to the second element by default. This was due to most menus having a header and us calling next_item() unconditionally. Now we first go to the first focusable item and then call next_item() as many times as needed to get to the specified initial_pos.