### PR TITLE
Return with "no success" when no options are given

### DIFF
--- a/clintermission/climenu.py
+++ b/clintermission/climenu.py
@@ -272,6 +272,10 @@ class CliMenu:
         event.app.exit()
 
     def _run(self):
+        if self._item_num == 0:
+            self._success = False
+            return
+
         self._preflight()
 
         class MenuColorizer(Processor):
@@ -284,6 +288,7 @@ class CliMenu:
         @self._kb.add('q', filter=~is_searching)
         @self._kb.add('c-c')
         def quit(event):
+            self._success = False
             event.app.exit()
 
         @self._kb.add('down', filter=~is_searching)


### PR DESCRIPTION
If the user gave us no options then we used to just raise a ValueError (due to initial_pos being out of range). In most - if not all - cases it would be more favorable to act the same way as if the selection has been aborted, so that's what we're doing now.