### PR TITLE
Add ctrl+n / ctrl+p as shortcuts for down and up

### DIFF
--- a/clintermission/climenu.py
+++ b/clintermission/climenu.py
@@ -293,11 +293,13 @@ class CliMenu:
 
         @self._kb.add('down', filter=~is_searching)
         @self._kb.add('j', filter=~is_searching)
+        @self._kb.add('c-n', filter=~is_searching)
         def down(event):
             self.next_item(1)
 
         @self._kb.add('up', filter=~is_searching)
         @self._kb.add('k', filter=~is_searching)
+        @self._kb.add('c-p', filter=~is_searching)
         def up(event):
             self.next_item(-1)
 


### PR DESCRIPTION
ctrl+n is used for "next item" aka down, ctrl+p as "previous item" aka up.

Fixes #1